### PR TITLE
tx-signing-service PR #2

### DIFF
--- a/tx-signing-service/Cargo.toml
+++ b/tx-signing-service/Cargo.toml
@@ -11,8 +11,10 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 near-crypto = "0.17.0"
 near-primitives = "0.17.0"
-
+near-jsonrpc-client = "0.6.0"
+anyhow = "1.0.75"
+serde_json = "1.0.108"
 
 [dev-dependencies]
 dotenv = "0.15.0"
-serde_json = "1.0.108"
+

--- a/tx-signing-service/src/main.rs
+++ b/tx-signing-service/src/main.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::fmt::Debug;
 use warp::Filter;
+use near_jsonrpc_client::{JsonRpcClient};
+use near_primitives::types::{AccountId};
+
+use serde_json::Value;
+use anyhow::Result;
 mod internal;
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -43,6 +48,49 @@ async fn generate_claim_receipt(info: QuestValidationInfo) -> Result<impl warp::
     }))
 }
 
+pub(crate) fn get_function_call_request(
+    block_height: u64,
+    account_id: near_primitives::types::AccountId,
+    method_name: &str,
+    args: serde_json::Value,
+) -> near_jsonrpc_client::methods::query::RpcQueryRequest {
+    near_jsonrpc_client::methods::query::RpcQueryRequest {
+        block_reference: near_primitives::types::BlockReference::BlockId(
+            near_primitives::types::BlockId::Height(block_height),
+        ),
+        request: near_primitives::views::QueryRequest::CallFunction {
+            account_id,
+            method_name: method_name.to_string(),
+            args: near_primitives::types::FunctionArgs::from(args.to_string().into_bytes()),
+        },
+    }
+}
+
+pub(crate) async fn get_indexer_config_id(
+    block_height: u64,
+    account_id: AccountId,
+    method_name: &str,
+    args: Value,
+) -> Result<String> {
+    // Create the function call request
+    let request = get_function_call_request(block_height, account_id, method_name, args);
+
+    // Create a JSON RPC client
+    let client = JsonRpcClient::connect("https://rpc.mainnet.near.org");
+
+    // Send the request and wait for the response
+    let response = client.call(request).await?;
+
+    let json_string = serde_json::to_string(&response)?;
+    let parsed: Value = serde_json::from_str(&json_string)?;
+
+    let indexer_config_id = parsed["indexer_config_id"].as_str()
+        .ok_or(anyhow::Error::msg("indexer_config_id not found or not a string"))?;
+
+    return Ok(indexer_config_id.to_string());
+
+}
+
 #[tokio::main]
 async fn main() {
     let validate = warp::path!("v1" / "validate" / String / String)
@@ -61,4 +109,6 @@ async fn main() {
     let routes = validate.or(generate_claim_receipt);
 
     warp::serve(routes).run(([127, 0, 0, 1], 8080)).await;
+    
+    
 }


### PR DESCRIPTION
Implemented `get_indexer_config_id` and `get_function_call_request`

I am not sure how to serialize the data coming from the `JsonRpcClient` as a `RpcQueryResponse` because I couldn't find a good example so right now I am doing a `json-to-string` of the `RpcQueryResponse` object assuming it will have a `indexer_config_id` field, then I am extracting that value and returning it. 

Since I don't have a way to test the rpc call right now I can use any suggestions, in the meantime I will keep doing research when I have another free spot during the day 